### PR TITLE
Terminal shell now nolonger deletes anything printed before

### DIFF
--- a/drivers/keyboard/keyboard.c
+++ b/drivers/keyboard/keyboard.c
@@ -28,10 +28,12 @@ void check_key(){
         
         if(c){
             if(c == 8 && screen_byte > 0){
-                screen_byte -= 2;
-                video_mem[screen_byte] = ' ';
-                video_mem[screen_byte + 1] = current_colour;
-                if(buffer_idx > 0) buffer_idx--;
+                  if(buffer_idx > 0){
+                    screen_byte -= 2;
+                    video_mem[screen_byte] = ' ';
+                    video_mem[screen_byte + 1] = current_colour;
+                    buffer_idx--;
+				  }				
             } else if(c == '\n'){
                 keyboard_buffer[buffer_idx] = '\0';
                 k_print("\n");

--- a/makefile
+++ b/makefile
@@ -1,7 +1,35 @@
 #mokeOS beta!!
-CC = i686-elf-gcc
-AS = nasm
-LNK = i686-elf-ld
+
+UNAME_S := $(shell uname -s 2>/dev/null || echo Unknown)
+
+# Prefer bare-metal cross tools; on Linux fall back to distro cross/native tools.
+ifeq ($(UNAME_S),Linux)
+	OS_CFLAGS := -fno-stack-protector -fno-pie -fno-pic -mno-mmx -mno-sse -mno-sse2 -mno-80387 -msoft-float -fno-tree-vectorize
+	ifneq ($(shell command -v i686-elf-gcc 2>/dev/null),)
+		CC := i686-elf-gcc
+		LNK := i686-elf-ld
+		ARCH_CFLAGS := -march=i386
+		ARCH_LDFLAGS :=
+	else ifneq ($(shell command -v i686-linux-gnu-gcc 2>/dev/null),)
+		CC := i686-linux-gnu-gcc
+		LNK := i686-linux-gnu-ld
+		ARCH_CFLAGS := -march=i386
+		ARCH_LDFLAGS :=
+	else
+		CC := gcc
+		LNK := ld
+		ARCH_CFLAGS := -m32 -march=i386
+		ARCH_LDFLAGS := -m elf_i386
+	endif
+else
+	OS_CFLAGS :=
+	CC := i686-elf-gcc
+	LNK := i686-elf-ld
+	ARCH_CFLAGS :=
+	ARCH_LDFLAGS :=
+endif
+
+AS := nasm
 
 CFLAGS = -std=gnu99 -ffreestanding -O2 -Wall -Wextra
 
@@ -19,13 +47,13 @@ OUTPUT = mokeos.bin
 all: $(OUTPUT)
 
 $(OUTPUT): $(OBJS)
-	$(LNK) -T linker.ld -o $(OUTPUT) $(OBJS)
+	$(LNK) $(ARCH_LDFLAGS) -T linker.ld -o $(OUTPUT) $(OBJS)
 
 boot.o: boot.s
 	$(AS) -f elf32 boot.s -o boot.o
 
 %.o: %.c
-	$(CC) -c $< -o $@ $(CFLAGS)
+	$(CC) -c $< -o $@ $(CFLAGS) $(ARCH_CFLAGS) $(OS_CFLAGS)
 
 clean:
 	rm -f $(OUTPUT)


### PR DESCRIPTION
backspace would delete way more than what a user typed. its now restricted to the actual writable buffer (visually, the original buffer already stayed at 0)